### PR TITLE
bug(cmake): fix cmake install exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ option(CB_V2G_INSTALL "Install the library (shared data might be installed anywa
 
 add_subdirectory(lib)
 
-message("-- Lib code based on cbexigen generator version: b64f296")
+message(STATUS "library code based on cbexigen generator version: b64f296")
 
 # tests
 if (CB_V2G_BUILD_TESTS)
@@ -28,25 +28,24 @@ endif()
 if (CB_V2G_INSTALL)
     install(
         TARGETS
-            cb_exi_codec
-            cb_din
-            cb_iso2
-            cb_iso20
-            cb_v2gtp
-        EXPORT cb_v2g-targets
+            cbv2g_exi_codec
+            cbv2g_din
+            cbv2g_iso2
+            cbv2g_iso20
+            cbv2g_tp
+        EXPORT cbv2g-targets
         LIBRARY
     )
 
     install(
         DIRECTORY include/
         TYPE INCLUDE
-        PATTERN "detail" EXCLUDE
     )
 
     evc_setup_package(
-        NAME everest-cb_v2g
-        NAMESPACE everest
-        EXPORT cb_v2g-targets
+        NAME cbv2g
+        NAMESPACE cbv2g
+        EXPORT cbv2g-targets
     )
 endif()
 

--- a/lib/cbv2g/CMakeLists.txt
+++ b/lib/cbv2g/CMakeLists.txt
@@ -1,6 +1,8 @@
-add_library(cb_exi_codec)
+add_library(cbv2g_exi_codec)
+add_library(cbv2g::exi_codec ALIAS cbv2g_exi_codec)
+set_property(TARGET cbv2g_exi_codec PROPERTY EXPORT_NAME exi_codec)
 
-target_sources(cb_exi_codec
+target_sources(cbv2g_exi_codec
     PRIVATE
         common/exi_basetypes_decoder.c
         common/exi_basetypes_encoder.c
@@ -10,19 +12,20 @@ target_sources(cb_exi_codec
         common/exi_types_decoder.c
 )
 
-target_include_directories(cb_exi_codec
+target_include_directories(cbv2g_exi_codec
     INTERFACE
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     PRIVATE
         ${PROJECT_SOURCE_DIR}/include
 )
 
-target_compile_features(cb_exi_codec PRIVATE c_std_99)
+target_compile_features(cbv2g_exi_codec PRIVATE c_std_99)
 
-add_library(cb_din)
-add_library(cb_v2g::DIN ALIAS cb_din)
+add_library(cbv2g_din)
+add_library(cbv2g::din ALIAS cbv2g_din)
+set_property(TARGET cbv2g_din PROPERTY EXPORT_NAME din)
 
-target_sources(cb_din
+target_sources(cbv2g_din
     PRIVATE
         app_handshake/appHand_Datatypes.c
         app_handshake/appHand_Decoder.c
@@ -32,23 +35,24 @@ target_sources(cb_din
         din/din_msgDefEncoder.c
 )
 
-target_include_directories(cb_din
+target_include_directories(cbv2g_din
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(cb_din
+target_link_libraries(cbv2g_din
     PUBLIC
-        cb_exi_codec
+        cbv2g::exi_codec
 )
 
-target_compile_features(cb_din PUBLIC c_std_99)
+target_compile_features(cbv2g_din PUBLIC c_std_99)
 
-add_library(cb_iso2)
-add_library(cb_v2g::ISO2 ALIAS cb_iso2)
+add_library(cbv2g_iso2)
+add_library(cbv2g::iso2 ALIAS cbv2g_iso2)
+set_property(TARGET cbv2g_iso2 PROPERTY EXPORT_NAME iso2)
 
-target_sources(cb_iso2
+target_sources(cbv2g_iso2
     PRIVATE
         app_handshake/appHand_Datatypes.c
         app_handshake/appHand_Decoder.c
@@ -58,23 +62,24 @@ target_sources(cb_iso2
         iso_2/iso2_msgDefEncoder.c
 )
 
-target_include_directories(cb_iso2
+target_include_directories(cbv2g_iso2
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(cb_iso2
+target_link_libraries(cbv2g_iso2
     PUBLIC
-        cb_exi_codec
+        cbv2g::exi_codec
 )
 
-target_compile_features(cb_iso2 PUBLIC c_std_99)
+target_compile_features(cbv2g_iso2 PUBLIC c_std_99)
 
-add_library(cb_iso20)
-add_library(cb_v2g::ISO20 ALIAS cb_iso20)
+add_library(cbv2g_iso20)
+add_library(cbv2g::iso20 ALIAS cbv2g_iso20)
+set_property(TARGET cbv2g_iso20 PROPERTY EXPORT_NAME iso20)
 
-target_sources(cb_iso20
+target_sources(cbv2g_iso20
     PRIVATE
         app_handshake/appHand_Datatypes.c
         app_handshake/appHand_Decoder.c
@@ -96,31 +101,33 @@ target_sources(cb_iso20
         iso_20/iso20_WPT_Encoder.c
 )
 
-target_include_directories(cb_iso20
+target_include_directories(cbv2g_iso20
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_link_libraries(cb_iso20
+target_link_libraries(cbv2g_iso20
     PUBLIC
-        cb_exi_codec
+        cbv2g::exi_codec
 )
 
-target_compile_features(cb_iso20 PUBLIC c_std_99)
+target_compile_features(cbv2g_iso20 PUBLIC c_std_99)
 
-add_library(cb_v2gtp)
-add_library(cb_v2g::V2GTP ALIAS cb_v2gtp)
+add_library(cbv2g_tp)
+add_library(cbv2g::tp ALIAS cbv2g_tp)
+set_property(TARGET cbv2g_tp PROPERTY EXPORT_NAME tp)
 
-target_sources(cb_v2gtp
+
+target_sources(cbv2g_tp
     PRIVATE
         exi_v2gtp.c
 )
 
-target_include_directories(cb_v2gtp
+target_include_directories(cbv2g_tp
     PUBLIC
         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(cb_v2gtp PUBLIC c_std_99)
+target_compile_features(cbv2g_tp PUBLIC c_std_99)


### PR DESCRIPTION
If you want to access cmake targets of a library, keep the following in mind.  Your library could be either consumed by an `add_subdirectory` (that's the way CPM and therefore edm works), or it could be consumed by `find_package` (the standard way for general package managers, yocto, debian ...).
If your library is consumed by `add_subdirectory`, then the consumer will see all of your *local* targets, even the ones, that you're not planning to expose/export (that is also one of the major drawbacks of `add_subdirectory`).  If your library is consumed by `find_package`, then only the exported targets are visible.
Usually, when you're maintaining a library, you want write it in a way that it can be consumed in both ways.  Meaning, both ways should be compatible with this usage
```
target_link_library(some_depending_target
    PRIVATE
        you_lib_namespace::your_lib_target
)
```
For this to work, you need to understand how the name of your library gets exported.
When your library is consumed by `add_subdirectory`, then everything is visible.  So if you create your library like this:
```
add_library(din)
add_library(cbv2g::din ALIAS din)
```
Your consumer will see both `din` and `cbv2g::din`.  Unfortunately, using `din` here is a bit risky, as this *short* target name might collide with other library targets (hence, when you want your library consumable with `add_subdirectory`, you should prefix basically every target - again, one of the drawbacks of using `add_subdirectory`). So lets make this compatible by using
```
add_library(cbv2g_din)
add_library(cbv2g::din ALIAS cbv2g_din)
```
You're expecting your consumer to use the alias (`cbv2g::din`). Now when you want to *install export* your targets, you need to create an export first and add your targets to it by
```
install(
    TARGETS
        cbv2g_din
        ...
    EXPORT
        cbv2g-targets
)
```
Here, `cbv2g-targets` is the name of the *export*, you want to install. Furthermore, it is not allowed to use `ALIAS` targets in this command. Secondly, you need to *install* this export by using
```
install(
    EXPORT
        cbv2g-targets
    NAMESPACE
        cbv2g
)
```
This command has a `NAMESPACE` argument and this namespace will get prepended to the name of the target.  But now, the name of the exported target will be `cbv2g::cbv2g_din`, because it adds the name of real, *non-aliased* target to the namespace.  But we actually want to have `cbv2g::din` as the exported target name.  In order to get this, we would either have to use `din` as the library target name, instead of `cbv2g_din` (but yielding the problems with possible collisions) or set the following property:
```
set_property(TARGET cbv2g_din PROPERTY EXPORT_NAME din)
```
This will basically tell cmake to use a different name than the target name when creating the export name of this library.

For maximum compatibility, I've chosen to set the `EXPORT_NAME` property.
Btw, the helper function `evc_setup_package` internally calls `install(EXPORTS ...)` and forwards the `NAMESPACE` argument.

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation - there is no documentation for this, but the content of the commit message might be a good base for a documentation on how to write cmake libraries
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

