### PR TITLE
Fix ISO20 bpt control mode for AC and DC

### DIFF
--- a/lib/cbv2g/iso_20/iso20_AC_Decoder.c
+++ b/lib/cbv2g/iso_20/iso20_AC_Decoder.c
@@ -16584,23 +16584,23 @@ static int decode_iso20_ac_AC_ChargeLoopReqType(exi_bitstream_t* stream, struct 
                 switch(eventCode)
                 {
                 case 0:
-                    // Event: START (BPT_Dynamic_AC_CLReqControlMode, BPT_Dynamic_AC_CLReqControlModeType (Dynamic_AC_CLReqControlModeType)); next=312
+                    // Event: START (BPT_Dynamic_AC_CLReqControlMode, BPT_Dynamic_AC_CLReqControlModeType (Dynamic_AC_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->BPT_Dynamic_AC_CLReqControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopReqType->BPT_Dynamic_AC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 312;
+                        grammar_id = 2;
                     }
                     break;
                 case 1:
-                    // Event: START (BPT_Scheduled_AC_CLReqControlMode, BPT_Scheduled_AC_CLReqControlModeType (Scheduled_AC_CLReqControlModeType)); next=312
+                    // Event: START (BPT_Scheduled_AC_CLReqControlMode, BPT_Scheduled_AC_CLReqControlModeType (Scheduled_AC_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->BPT_Scheduled_AC_CLReqControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopReqType->BPT_Scheduled_AC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 312;
+                        grammar_id = 2;
                     }
                     break;
                 case 2:
@@ -16624,49 +16624,6 @@ static int decode_iso20_ac_AC_ChargeLoopReqType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 4:
-                    // Event: START (Scheduled_AC_CLReqControlMode, Scheduled_AC_CLReqControlModeType (Scheduled_CLReqControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_ac_Scheduled_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->Scheduled_AC_CLReqControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopReqType->Scheduled_AC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                default:
-                    error = EXI_ERROR__UNKNOWN_EVENT_CODE;
-                    break;
-                }
-            }
-            break;
-        case 312:
-            // Grammar: ID=312; read/write bits=2; START (CLReqControlMode), START (Dynamic_AC_CLReqControlMode), START (Scheduled_AC_CLReqControlMode)
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
-            if (error == 0)
-            {
-                switch(eventCode)
-                {
-                case 0:
-                    // Abstract element or type: CLReqControlMode, CLReqControlModeType (CLReqControlModeType)
-                    // decode: element
-                    error = decode_iso20_ac_CLReqControlModeType(stream, &AC_ChargeLoopReqType->CLReqControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopReqType->CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 1:
-                    // Event: START (Dynamic_AC_CLReqControlMode, Dynamic_AC_CLReqControlModeType (Dynamic_CLReqControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_ac_Dynamic_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->Dynamic_AC_CLReqControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopReqType->Dynamic_AC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 2:
                     // Event: START (Scheduled_AC_CLReqControlMode, Scheduled_AC_CLReqControlModeType (Scheduled_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_Scheduled_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->Scheduled_AC_CLReqControlMode);
@@ -17766,23 +17723,23 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 4:
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 5:
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 6:
@@ -17859,23 +17816,23 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 3:
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 4:
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 5:
@@ -17942,23 +17899,23 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 2:
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 3:
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 4:
@@ -18015,23 +17972,23 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 1:
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 2:
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 3:
@@ -18078,23 +18035,23 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                 switch(eventCode)
                 {
                 case 0:
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, BPT_Dynamic_AC_CLResControlModeType (Dynamic_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 1:
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, BPT_Scheduled_AC_CLResControlModeType (Scheduled_AC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == 0)
                     {
                         AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                     break;
                 case 2:
@@ -18118,49 +18075,6 @@ static int decode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 4:
-                    // Event: START (Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType (Scheduled_CLResControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_ac_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->Scheduled_AC_CLResControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopResType->Scheduled_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                default:
-                    error = EXI_ERROR__UNKNOWN_EVENT_CODE;
-                    break;
-                }
-            }
-            break;
-        case 333:
-            // Grammar: ID=333; read/write bits=2; START (CLResControlMode), START (Dynamic_AC_CLResControlMode), START (Scheduled_AC_CLResControlMode)
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
-            if (error == 0)
-            {
-                switch(eventCode)
-                {
-                case 0:
-                    // Abstract element or type: CLResControlMode, CLResControlModeType (CLResControlModeType)
-                    // decode: element
-                    error = decode_iso20_ac_CLResControlModeType(stream, &AC_ChargeLoopResType->CLResControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopResType->CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 1:
-                    // Event: START (Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType (Dynamic_CLResControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_ac_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->Dynamic_AC_CLResControlMode);
-                    if (error == 0)
-                    {
-                        AC_ChargeLoopResType->Dynamic_AC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 2:
                     // Event: START (Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType (Scheduled_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_ac_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->Scheduled_AC_CLResControlMode);

--- a/lib/cbv2g/iso_20/iso20_AC_Encoder.c
+++ b/lib/cbv2g/iso_20/iso20_AC_Encoder.c
@@ -15792,11 +15792,11 @@ static int encode_iso20_ac_AC_ChargeLoopReqType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLReqControlMode, Dynamic_AC_CLReqControlModeType); next=312
+                    // Event: START (BPT_Dynamic_AC_CLReqControlMode, Dynamic_AC_CLReqControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->BPT_Dynamic_AC_CLReqControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 312;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -15805,11 +15805,11 @@ static int encode_iso20_ac_AC_ChargeLoopReqType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 1);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLReqControlMode, Scheduled_AC_CLReqControlModeType); next=312
+                    // Event: START (BPT_Scheduled_AC_CLReqControlMode, Scheduled_AC_CLReqControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->BPT_Scheduled_AC_CLReqControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 312;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -15842,48 +15842,6 @@ static int encode_iso20_ac_AC_ChargeLoopReqType(exi_bitstream_t* stream, const s
             else
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 4);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Scheduled_AC_CLReqControlMode, Scheduled_CLReqControlModeType); next=2
-                    error = encode_iso20_ac_Scheduled_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->Scheduled_AC_CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            break;
-        case 312:
-            // Grammar: ID=312; read/write bits=2; START (CLReqControlMode), START (Dynamic_AC_CLReqControlMode), START (Scheduled_AC_CLReqControlMode)
-            if (AC_ChargeLoopReqType->CLReqControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Abstract element or type: START (CLReqControlModeType); next=2
-                    error = encode_iso20_ac_CLReqControlModeType(stream, &AC_ChargeLoopReqType->CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else if (AC_ChargeLoopReqType->Dynamic_AC_CLReqControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 1);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Dynamic_AC_CLReqControlMode, Dynamic_CLReqControlModeType); next=2
-                    error = encode_iso20_ac_Dynamic_AC_CLReqControlModeType(stream, &AC_ChargeLoopReqType->Dynamic_AC_CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
                     // Event: START (Scheduled_AC_CLReqControlMode, Scheduled_CLReqControlModeType); next=2
@@ -16928,11 +16886,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 4, 4);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -16941,11 +16899,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 4, 5);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17035,11 +16993,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 4, 3);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17048,11 +17006,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 4, 4);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17129,11 +17087,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17142,11 +17100,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 3);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17210,11 +17168,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 1);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17223,11 +17181,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17278,11 +17236,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Dynamic_AC_CLResControlMode, Dynamic_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Dynamic_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17291,11 +17249,11 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 1);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=333
+                    // Event: START (BPT_Scheduled_AC_CLResControlMode, Scheduled_AC_CLResControlModeType); next=2
                     error = encode_iso20_ac_BPT_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->BPT_Scheduled_AC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 333;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -17328,48 +17286,6 @@ static int encode_iso20_ac_AC_ChargeLoopResType(exi_bitstream_t* stream, const s
             else
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 4);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Scheduled_AC_CLResControlMode, Scheduled_CLResControlModeType); next=2
-                    error = encode_iso20_ac_Scheduled_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->Scheduled_AC_CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            break;
-        case 333:
-            // Grammar: ID=333; read/write bits=2; START (CLResControlMode), START (Dynamic_AC_CLResControlMode), START (Scheduled_AC_CLResControlMode)
-            if (AC_ChargeLoopResType->CLResControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Abstract element or type: START (CLResControlModeType); next=2
-                    error = encode_iso20_ac_CLResControlModeType(stream, &AC_ChargeLoopResType->CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else if (AC_ChargeLoopResType->Dynamic_AC_CLResControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 1);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Dynamic_AC_CLResControlMode, Dynamic_CLResControlModeType); next=2
-                    error = encode_iso20_ac_Dynamic_AC_CLResControlModeType(stream, &AC_ChargeLoopResType->Dynamic_AC_CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
                     // Event: START (Scheduled_AC_CLResControlMode, Scheduled_CLResControlModeType); next=2

--- a/lib/cbv2g/iso_20/iso20_DC_Decoder.c
+++ b/lib/cbv2g/iso_20/iso20_DC_Decoder.c
@@ -13602,23 +13602,23 @@ static int decode_iso20_dc_DC_ChargeLoopReqType(exi_bitstream_t* stream, struct 
                 switch(eventCode)
                 {
                 case 0:
-                    // Event: START (BPT_Dynamic_DC_CLReqControlMode, BPT_Dynamic_DC_CLReqControlModeType (Dynamic_DC_CLReqControlModeType)); next=276
+                    // Event: START (BPT_Dynamic_DC_CLReqControlMode, BPT_Dynamic_DC_CLReqControlModeType (Dynamic_DC_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->BPT_Dynamic_DC_CLReqControlMode);
                     if (error == 0)
                     {
                         DC_ChargeLoopReqType->BPT_Dynamic_DC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 276;
+                        grammar_id = 2;
                     }
                     break;
                 case 1:
-                    // Event: START (BPT_Scheduled_DC_CLReqControlMode, BPT_Scheduled_DC_CLReqControlModeType (Scheduled_DC_CLReqControlModeType)); next=276
+                    // Event: START (BPT_Scheduled_DC_CLReqControlMode, BPT_Scheduled_DC_CLReqControlModeType (Scheduled_DC_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_BPT_Scheduled_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->BPT_Scheduled_DC_CLReqControlMode);
                     if (error == 0)
                     {
                         DC_ChargeLoopReqType->BPT_Scheduled_DC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 276;
+                        grammar_id = 2;
                     }
                     break;
                 case 2:
@@ -13642,49 +13642,6 @@ static int decode_iso20_dc_DC_ChargeLoopReqType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 4:
-                    // Event: START (Scheduled_DC_CLReqControlMode, Scheduled_DC_CLReqControlModeType (Scheduled_CLReqControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_dc_Scheduled_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->Scheduled_DC_CLReqControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopReqType->Scheduled_DC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                default:
-                    error = EXI_ERROR__UNKNOWN_EVENT_CODE;
-                    break;
-                }
-            }
-            break;
-        case 276:
-            // Grammar: ID=276; read/write bits=2; START (CLReqControlMode), START (Dynamic_DC_CLReqControlMode), START (Scheduled_DC_CLReqControlMode)
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
-            if (error == 0)
-            {
-                switch(eventCode)
-                {
-                case 0:
-                    // Abstract element or type: CLReqControlMode, CLReqControlModeType (CLReqControlModeType)
-                    // decode: element
-                    error = decode_iso20_dc_CLReqControlModeType(stream, &DC_ChargeLoopReqType->CLReqControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopReqType->CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 1:
-                    // Event: START (Dynamic_DC_CLReqControlMode, Dynamic_DC_CLReqControlModeType (Dynamic_CLReqControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_dc_Dynamic_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->Dynamic_DC_CLReqControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopReqType->Dynamic_DC_CLReqControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 2:
                     // Event: START (Scheduled_DC_CLReqControlMode, Scheduled_DC_CLReqControlModeType (Scheduled_CLReqControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_Scheduled_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->Scheduled_DC_CLReqControlMode);
@@ -14723,23 +14680,23 @@ static int decode_iso20_dc_DC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                 switch(eventCode)
                 {
                 case 0:
-                    // Event: START (BPT_Dynamic_DC_CLResControlMode, BPT_Dynamic_DC_CLResControlModeType (Dynamic_DC_CLResControlModeType)); next=300
+                    // Event: START (BPT_Dynamic_DC_CLResControlMode, BPT_Dynamic_DC_CLResControlModeType (Dynamic_DC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_BPT_Dynamic_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->BPT_Dynamic_DC_CLResControlMode);
                     if (error == 0)
                     {
                         DC_ChargeLoopResType->BPT_Dynamic_DC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 300;
+                        grammar_id = 2;
                     }
                     break;
                 case 1:
-                    // Event: START (BPT_Scheduled_DC_CLResControlMode, BPT_Scheduled_DC_CLResControlModeType (Scheduled_DC_CLResControlModeType)); next=300
+                    // Event: START (BPT_Scheduled_DC_CLResControlMode, BPT_Scheduled_DC_CLResControlModeType (Scheduled_DC_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_BPT_Scheduled_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->BPT_Scheduled_DC_CLResControlMode);
                     if (error == 0)
                     {
                         DC_ChargeLoopResType->BPT_Scheduled_DC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 300;
+                        grammar_id = 2;
                     }
                     break;
                 case 2:
@@ -14763,49 +14720,6 @@ static int decode_iso20_dc_DC_ChargeLoopResType(exi_bitstream_t* stream, struct 
                     }
                     break;
                 case 4:
-                    // Event: START (Scheduled_DC_CLResControlMode, Scheduled_DC_CLResControlModeType (Scheduled_CLResControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_dc_Scheduled_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->Scheduled_DC_CLResControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopResType->Scheduled_DC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                default:
-                    error = EXI_ERROR__UNKNOWN_EVENT_CODE;
-                    break;
-                }
-            }
-            break;
-        case 300:
-            // Grammar: ID=300; read/write bits=2; START (CLResControlMode), START (Dynamic_DC_CLResControlMode), START (Scheduled_DC_CLResControlMode)
-            error = exi_basetypes_decoder_nbit_uint(stream, 2, &eventCode);
-            if (error == 0)
-            {
-                switch(eventCode)
-                {
-                case 0:
-                    // Abstract element or type: CLResControlMode, CLResControlModeType (CLResControlModeType)
-                    // decode: element
-                    error = decode_iso20_dc_CLResControlModeType(stream, &DC_ChargeLoopResType->CLResControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopResType->CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 1:
-                    // Event: START (Dynamic_DC_CLResControlMode, Dynamic_DC_CLResControlModeType (Dynamic_CLResControlModeType)); next=2
-                    // decode: element
-                    error = decode_iso20_dc_Dynamic_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->Dynamic_DC_CLResControlMode);
-                    if (error == 0)
-                    {
-                        DC_ChargeLoopResType->Dynamic_DC_CLResControlMode_isUsed = 1u;
-                        grammar_id = 2;
-                    }
-                    break;
-                case 2:
                     // Event: START (Scheduled_DC_CLResControlMode, Scheduled_DC_CLResControlModeType (Scheduled_CLResControlModeType)); next=2
                     // decode: element
                     error = decode_iso20_dc_Scheduled_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->Scheduled_DC_CLResControlMode);

--- a/lib/cbv2g/iso_20/iso20_DC_Encoder.c
+++ b/lib/cbv2g/iso_20/iso20_DC_Encoder.c
@@ -11773,11 +11773,11 @@ static int encode_iso20_dc_DC_ChargeLoopReqType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_DC_CLReqControlMode, Dynamic_DC_CLReqControlModeType); next=276
+                    // Event: START (BPT_Dynamic_DC_CLReqControlMode, Dynamic_DC_CLReqControlModeType); next=2
                     error = encode_iso20_dc_BPT_Dynamic_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->BPT_Dynamic_DC_CLReqControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 276;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -11786,11 +11786,11 @@ static int encode_iso20_dc_DC_ChargeLoopReqType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 1);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_DC_CLReqControlMode, Scheduled_DC_CLReqControlModeType); next=276
+                    // Event: START (BPT_Scheduled_DC_CLReqControlMode, Scheduled_DC_CLReqControlModeType); next=2
                     error = encode_iso20_dc_BPT_Scheduled_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->BPT_Scheduled_DC_CLReqControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 276;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -11823,48 +11823,6 @@ static int encode_iso20_dc_DC_ChargeLoopReqType(exi_bitstream_t* stream, const s
             else
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 4);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Scheduled_DC_CLReqControlMode, Scheduled_CLReqControlModeType); next=2
-                    error = encode_iso20_dc_Scheduled_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->Scheduled_DC_CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            break;
-        case 276:
-            // Grammar: ID=276; read/write bits=2; START (CLReqControlMode), START (Dynamic_DC_CLReqControlMode), START (Scheduled_DC_CLReqControlMode)
-            if (DC_ChargeLoopReqType->CLReqControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Abstract element or type: START (CLReqControlModeType); next=2
-                    error = encode_iso20_dc_CLReqControlModeType(stream, &DC_ChargeLoopReqType->CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else if (DC_ChargeLoopReqType->Dynamic_DC_CLReqControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 1);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Dynamic_DC_CLReqControlMode, Dynamic_CLReqControlModeType); next=2
-                    error = encode_iso20_dc_Dynamic_DC_CLReqControlModeType(stream, &DC_ChargeLoopReqType->Dynamic_DC_CLReqControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
                     // Event: START (Scheduled_DC_CLReqControlMode, Scheduled_CLReqControlModeType); next=2
@@ -12594,11 +12552,11 @@ static int encode_iso20_dc_DC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 0);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Dynamic_DC_CLResControlMode, Dynamic_DC_CLResControlModeType); next=300
+                    // Event: START (BPT_Dynamic_DC_CLResControlMode, Dynamic_DC_CLResControlModeType); next=2
                     error = encode_iso20_dc_BPT_Dynamic_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->BPT_Dynamic_DC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 300;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -12607,11 +12565,11 @@ static int encode_iso20_dc_DC_ChargeLoopResType(exi_bitstream_t* stream, const s
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 1);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
-                    // Event: START (BPT_Scheduled_DC_CLResControlMode, Scheduled_DC_CLResControlModeType); next=300
+                    // Event: START (BPT_Scheduled_DC_CLResControlMode, Scheduled_DC_CLResControlModeType); next=2
                     error = encode_iso20_dc_BPT_Scheduled_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->BPT_Scheduled_DC_CLResControlMode);
                     if (error == EXI_ERROR__NO_ERROR)
                     {
-                        grammar_id = 300;
+                        grammar_id = 2;
                     }
                 }
             }
@@ -12644,48 +12602,6 @@ static int encode_iso20_dc_DC_ChargeLoopResType(exi_bitstream_t* stream, const s
             else
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 3, 4);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Scheduled_DC_CLResControlMode, Scheduled_CLResControlModeType); next=2
-                    error = encode_iso20_dc_Scheduled_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->Scheduled_DC_CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            break;
-        case 300:
-            // Grammar: ID=300; read/write bits=2; START (CLResControlMode), START (Dynamic_DC_CLResControlMode), START (Scheduled_DC_CLResControlMode)
-            if (DC_ChargeLoopResType->CLResControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Abstract element or type: START (CLResControlModeType); next=2
-                    error = encode_iso20_dc_CLResControlModeType(stream, &DC_ChargeLoopResType->CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else if (DC_ChargeLoopResType->Dynamic_DC_CLResControlMode_isUsed == 1u)
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 1);
-                if (error == EXI_ERROR__NO_ERROR)
-                {
-                    // Event: START (Dynamic_DC_CLResControlMode, Dynamic_CLResControlModeType); next=2
-                    error = encode_iso20_dc_Dynamic_DC_CLResControlModeType(stream, &DC_ChargeLoopResType->Dynamic_DC_CLResControlMode);
-                    if (error == EXI_ERROR__NO_ERROR)
-                    {
-                        grammar_id = 2;
-                    }
-                }
-            }
-            else
-            {
-                error = exi_basetypes_encoder_nbit_uint(stream, 2, 2);
                 if (error == EXI_ERROR__NO_ERROR)
                 {
                     // Event: START (Scheduled_DC_CLResControlMode, Scheduled_CLResControlModeType); next=2


### PR DESCRIPTION
## Describe your changes
Fix ISO20 bpt control mode for AC and DC. This should be fixed in cbexigen, too.

## Issue ticket number and link
libcbv2g tries to encode a second option CLReqControlMode, which is not defined in the xsd. That applies for AC and DC.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

