### PR TITLE
Resolve compiler warnings/errors

### DIFF
--- a/include/cbv2g/common/exi_bitstream.h
+++ b/include/cbv2g/common/exi_bitstream.h
@@ -39,7 +39,7 @@ extern "C" {
 
 typedef void (*exi_status_callback)(int message_id, int status_code, int value_1, int value_2);
 
-typedef struct {
+typedef struct exi_bitstream {
     /* byte array size and data */
     uint8_t* data;
     size_t data_size;

--- a/lib/cbv2g/app_handshake/appHand_Decoder.c
+++ b/lib/cbv2g/app_handshake/appHand_Decoder.c
@@ -26,8 +26,8 @@
 #include "cbv2g/common/exi_header.h"
 #include "cbv2g/common/exi_types_decoder.h"
 #include "cbv2g/app_handshake/appHand_Datatypes.h"
-
-
+#include "cbv2g/app_handshake/appHand_Decoder.h"
+#include "cbv2g/app_handshake/appHand_Encoder.h"
 
 static int decode_appHand_AppProtocolType(exi_bitstream_t* stream, struct appHand_AppProtocolType* AppProtocolType);
 static int decode_appHand_supportedAppProtocolReq(exi_bitstream_t* stream, struct appHand_supportedAppProtocolReq* supportedAppProtocolReq);

--- a/lib/cbv2g/app_handshake/appHand_Encoder.c
+++ b/lib/cbv2g/app_handshake/appHand_Encoder.c
@@ -24,7 +24,7 @@
 #include "cbv2g/common/exi_error_codes.h"
 #include "cbv2g/common/exi_header.h"
 #include "cbv2g/app_handshake/appHand_Datatypes.h"
-
+#include "cbv2g/app_handshake/appHand_Encoder.h"
 
 
 static int encode_appHand_AppProtocolType(exi_bitstream_t* stream, const struct appHand_AppProtocolType* AppProtocolType);

--- a/lib/cbv2g/common/exi_basetypes_encoder.c
+++ b/lib/cbv2g/common/exi_basetypes_encoder.c
@@ -71,7 +71,7 @@ int exi_basetypes_encoder_bytes(exi_bitstream_t* stream, size_t bytes_len, const
         return EXI_ERROR__BYTE_BUFFER_TOO_SMALL;
     }
 
-    uint8_t* current_byte = (uint8_t*)bytes;
+    const uint8_t* current_byte = bytes;
 
     for (size_t n = 0; n < bytes_len; n++)
     {
@@ -253,7 +253,7 @@ int exi_basetypes_encoder_characters(exi_bitstream_t* stream, size_t characters_
         return EXI_ERROR__CHARACTER_BUFFER_TOO_SMALL;
     }
 
-    uint8_t* current_char = (uint8_t*)characters;
+    const uint8_t* current_char = (const uint8_t *)characters;
 
     for (size_t n = 0; n < characters_len; n++)
     {

--- a/lib/cbv2g/iso_2/iso2_msgDefEncoder.c
+++ b/lib/cbv2g/iso_2/iso2_msgDefEncoder.c
@@ -409,7 +409,7 @@ static int encode_iso2_TransformsType(exi_bitstream_t* stream, const struct iso2
             break;
         case 8:
             // Grammar: ID=8; read/write bits=2; START (Transform), END Element
-            if (1 == 0)
+            if (1 == 0) // What's going on here?
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
                 if (error == EXI_ERROR__NO_ERROR)
@@ -5651,7 +5651,7 @@ static int encode_iso2_SignatureType(exi_bitstream_t* stream, const struct iso2_
             break;
         case 121:
             // Grammar: ID=121; read/write bits=2; START (Object), END Element
-            if (1 == 0)
+            if (1 == 0) // Whats going on here?
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
                 if (error == EXI_ERROR__NO_ERROR)
@@ -5703,7 +5703,7 @@ static int encode_iso2_SignatureType(exi_bitstream_t* stream, const struct iso2_
             break;
         case 123:
             // Grammar: ID=123; read/write bits=2; START (Object), END Element
-            if (1 == 0)
+            if (1 == 0) // What's going on here?
             {
                 error = exi_basetypes_encoder_nbit_uint(stream, 2, 0);
                 if (error == EXI_ERROR__NO_ERROR)
@@ -16739,7 +16739,7 @@ int encode_iso2_exiFragment(exi_bitstream_t* stream, struct iso2_exiFragment* ex
     if (error == EXI_ERROR__NO_ERROR)
     {
         // AC_EVChargeParameter (urn:iso:15118:2:2013:MsgDataTypes)
-        if (0 == 1)
+        if (0 == 1) // What's going on here?
         {
             error = EXI_ERROR__NOT_IMPLEMENTED_YET;
         }


### PR DESCRIPTION
## Describe your changes
Changes to remove compiler errors and warnings when compiled under MSVC and GCC.
Sorry, I don't know if these changes belong to this repository or the code that generates these files.

The change to exi_bitstream.h to alter structure definition to "typedef struct exi_bitstream " is to allow forward declaration of exi_bitstream in c++.

NOTE:  There are also some flagged lines (not to be merged) in iso2_msgDefEncoder.c that may indicate an error with the code generator.

## Issue ticket number and link

## Checklist before requesting a review

- [yes] I have performed a self-review of my code
- [ yes] I have made corresponding changes to the documentation
- [ yes] I read the [contribution documentation](https://github.com/EVerest/EVerest/blob/main/CONTRIBUTING.md) and made sure that my changes meet its requirements

